### PR TITLE
rebind "most" of the keys to extended F13-24 keys

### DIFF
--- a/qmk_firmware/Dockerfile
+++ b/qmk_firmware/Dockerfile
@@ -1,4 +1,4 @@
-FROM qmkfm/qmk_firmware
+FROM qmkfm/qmk_firmware@sha256:470a263d42282eea66b3f48a3416a86e33fca16187e98fe2940d8fa4291857a6
 
 RUN mkdir /output
 

--- a/qmk_firmware/README.md
+++ b/qmk_firmware/README.md
@@ -51,6 +51,6 @@ Then after a second reboot, I installed drivers (again) and was able to flash my
 
 Because this is all so foreign to me, I even removed my actual keyboard to avoid the risk of destroying it on accident.
 
-Speaking about my actual keyboard, that doesn't quite work yet for this project. I did at one point but that was years ago and I forget why it doesn't work now. This file `qmk_firmware/keyboards/dztech/dz60rgb_ansi/keymaps/default/keymap.c` is empty with `<removed>` and it just fails 🤷‍♂️.
+Speaking about my actual keyboard, that doesn't quite work yet for this project. I did at one point but that was years ago and I forget why it doesn't work now. This file [`keyboards/dztech/dz60rgb_ansi/keymaps/default/keymap.c`](keyboards/dztech/dz60rgb_ansi/keymaps/default/keymap.c) is empty with `<removed>` and it just fails 🤷‍♂️.
 
 At some point, if my main keyboard dies, I will need to fully rebuild this project and make it actually usable for my keyboard. I will certainly keep the current docker build setup as it is quite nice. I can build a `.hex` file for my dumbpad on a mac, copy it to my windows device, boot up QMK, and still get a successful flash. So that is cool.

--- a/qmk_firmware/README.md
+++ b/qmk_firmware/README.md
@@ -15,14 +15,13 @@ Tip: If you are on windows, you can follow this official guide to install all of
 ### Steps
 
 1. From this directory, run the following command: `./run.sh`
-2. Follow the prompts - Example: `-kb: dumbpad` and `-km default`
-3. Check for the output hex file in this directory. Example: `dumbpad_v1x_dualencoder_default.hex.output`
-4. Rename/remove the `.output` from the filename to flash with QMK Toolbox
-5. 🎉
+2. Follow the prompts - Example: `-kb: dumbpad` and `-km birki`
+3. Check for the output hex file in this directory. Example: `dumbpad-birki.hex`
+4. 🎉
 
 #### Explanation
 
-The following steps above just built a Docker container. This docker container copied all the files from this directory and attached a volume to write the file back into our repo. It then built and compiled the keyboard/macro we provided during runtime. This is fed through `qmk compile` and then saved to our working directory as `<filename>.hex.output`. We then have to rename this file to remove the `.output` to use it within QMK Toolbox for flashing.
+The following steps above just built a Docker container. This docker container copied all the files from this directory and attached a volume to write the file back into our repo. It then built and compiled the keyboard/macro we provided during runtime. This is fed through `qmk compile` and then saved to our working directory as `<filename>.hex.output`. It is then renamed to remove the `.output` to use it within QMK Toolbox for flashing.
 
 ### Installing my custom keymap
 
@@ -43,3 +42,15 @@ Open QMK Toolbox and flash using the hex file compiled and stored in this direct
 ![demo](demo.png)
 
 > In my case, the compiled hex file is named `dumbpad-birki.hex`
+
+### Bonus Notes
+
+I needed to re-installed QMK Toolbox, run it as administrator and installed all drivers. I even had to reboot my PC once to finish the install I think.
+
+Then after a second reboot, I installed drivers (again) and was able to flash my dumbpad. There is a little button thingy I had to press to get it into flashing mode.
+
+Because this is all so foreign to me, I even removed my actual keyboard to avoid the risk of destroying it on accident.
+
+Speaking about my actual keyboard, that doesn't quite work yet for this project. I did at one point but that was years ago and I forget why it doesn't work now. This file `qmk_firmware/keyboards/dztech/dz60rgb_ansi/keymaps/default/keymap.c` is empty with `<removed>` and it just fails 🤷‍♂️.
+
+At some point, if my main keyboard dies, I will need to fully rebuild this project and make it actually usable for my keyboard. I will certainly keep the current docker build setup as it is quite nice. I can build a `.hex` file for my dumbpad on a mac, copy it to my windows device, boot up QMK, and still get a successful flash. So that is cool.

--- a/qmk_firmware/keyboards/dumbpad/v1x_dualencoder/keymaps/birki/keymap.c
+++ b/qmk_firmware/keyboards/dumbpad/v1x_dualencoder/keymaps/birki/keymap.c
@@ -45,163 +45,109 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KEY_0:
         if (record->event.pressed) {
             // when keycode KEY_0 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P0);
+            register_code(KC_F13);
         } else {
             // when keycode KEY_0 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P0);
+            unregister_code(KC_F13);
         }
         break;
     case KEY_1:
         if (record->event.pressed) {
             // when keycode KEY_1 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P1);
+            register_code(KC_F14);
         } else {
             // when keycode KEY_1 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P1);
+            unregister_code(KC_F14);
         }
         break;
     case KEY_2:
         if (record->event.pressed) {
             // when keycode KEY_2 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P2);
+            register_code(KC_F15);
         } else {
             // when keycode KEY_2 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P2);
+            unregister_code(KC_F15);
         }
         break;
     case KEY_3:
         if (record->event.pressed) {
             // when keycode KEY_3 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P3);
+            register_code(KC_F16);
         } else {
             // when keycode KEY_3 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P3);
+            unregister_code(KC_F16);
         }
         break;
     case KEY_4:
         if (record->event.pressed) {
             // when keycode KEY_4 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P4);
+            register_code(KC_F17);
         } else {
             // when keycode KEY_4 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P4);
+            unregister_code(KC_F17);
         }
         break;
     case KEY_5:
         if (record->event.pressed) {
             // when keycode KEY_5 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P5);
+            register_code(KC_F18);
         } else {
             // when keycode KEY_5 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P5);
+            unregister_code(KC_F18);
         }
         break;
     case KEY_6:
         if (record->event.pressed) {
             // when keycode KEY_6 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P6);
+            register_code(KC_F19);
         } else {
             // when keycode KEY_6 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P6);
+            unregister_code(KC_F19);
         }
         break;
     case KEY_7:
         if (record->event.pressed) {
             // when keycode KEY_7 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P7);
+            register_code(KC_F20);
         } else {
             // when keycode KEY_7 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P7);
+            unregister_code(KC_F20);
         }
         break;
     case KEY_8:
         if (record->event.pressed) {
             // when keycode KEY_8 is pressed
-
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P8);
-            
+            register_code(KC_F20);
         } else {
             // when keycode KEY_8 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P8);
+            unregister_code(KC_F20);
         }
         break;
     case KEY_9:
         if (record->event.pressed) {
             // when keycode KEY_9 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_P9);
+            register_code(KC_F21);
         } else {
             // when keycode KEY_9 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_P9);
+            unregister_code(KC_F21);
         }
         break;
     case KEY_10:
         if (record->event.pressed) {
             // when keycode KEY_10 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_LSFT);
-            register_code(KC_P0);
+            register_code(KC_F22);
         } else {
             // when keycode KEY_10 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_LSFT);
-            unregister_code(KC_P0);
+            unregister_code(KC_F22);
         }
         break;
     case KEY_11:
         if (record->event.pressed) {
             // when keycode KEY_11 is pressed
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_LSFT);
-            register_code(KC_P1);
+            register_code(KC_F23);
         } else {
             // when keycode KEY_11 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_LSFT);
-            unregister_code(KC_P1);
+            unregister_code(KC_F23);
         }
         break;
     case KEY_12:
@@ -272,16 +218,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 led_01_toggle = true;
             }
 
-            register_code(KC_LCTL);
-            register_code(KC_LALT);
-            register_code(KC_LSFT);
-            register_code(KC_P6);
+            register_code(KC_F24);
         } else {
             // when keycode KEY_16 is released
-            unregister_code(KC_LCTL);
-            unregister_code(KC_LALT);
-            unregister_code(KC_LSFT);
-            unregister_code(KC_P6);
+            unregister_code(KC_F24);
         }
         break;
     }


### PR DESCRIPTION
There were not enough F keys so this is the best I can do.

Having keys on the dumbpad map to F13-F24 is a good solution to the problem of mapping to `ctrl + shift + ->` as that causes so many conflicts with other open programs and is just bad